### PR TITLE
fix: remove deprecated action usage from deploy workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,14 +8,14 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@main
+      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
         name: Deploy to Vercel
         with:
           node_version: 22

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,7 +15,7 @@ jobs:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
+      - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy to Vercel
         with:
           node_version: 22

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -17,7 +17,7 @@ jobs:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
+      - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy to Vercel
         with:
           node_version: 22

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -10,14 +10,14 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@main
+      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
         name: Deploy to Vercel
         with:
           node_version: 22

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -9,14 +9,14 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@main
+      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
         name: Deploy to Vercel
         with:
           node_version: 22

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -16,7 +16,7 @@ jobs:
           version: 10.32.1
           run_install: false
 
-      - uses: darwinia-network/devops/actions/smart-vercel@def47cdab63e6ff6c5ab0014c58dc3f23cb09bba
+      - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy to Vercel
         with:
           node_version: 22


### PR DESCRIPTION
## Summary
- upgrade deploy workflows to `actions/checkout@v5`
- consume the merged `darwinia-network/devops/actions/smart-vercel@main` fix instead of pinning a temporary commit
- preserve the existing deploy workflow structure while removing deprecated GitHub Actions usage from the deploy path

## Upstream
- darwinia-network/devops#28

## Validation
- `pnpm verify`
- `pnpm exec prettier --check .github/workflows/deploy-dev.yml .github/workflows/deploy-stg.yml .github/workflows/deploy-prd.yml`
- `git diff --check`
