### PR TITLE
Add homepage reviewed-source provenance

### DIFF
--- a/scripts/verify-design-contract.mjs
+++ b/scripts/verify-design-contract.mjs
@@ -68,6 +68,14 @@ requireIncludes(home, 'Agent × x402', 'Atlas x402 access flow');
 requireIncludes(home, '30K+', 'portfolio proposal metric');
 requireIncludes(
   home,
+  'data-od-id="homepage-content-provenance"',
+  'homepage content provenance block'
+);
+requireIncludes(home, 'Canonical owner:', 'homepage canonical content owner');
+requireIncludes(home, 'Editorial review:', 'homepage editorial review date');
+requireIncludes(home, 'not deploy or build', 'content-review freshness distinction');
+requireIncludes(
+  home,
   'mailto:contact@degov.ai?subject=Atlas%20data%20partnership',
   'Atlas contact path'
 );

--- a/scripts/verify-social-metadata.mjs
+++ b/scripts/verify-social-metadata.mjs
@@ -61,12 +61,25 @@ function requireMetadata(path, canonicalUrl, expected) {
   }
 
   for (const [key, values] of metadata) {
-    if (values.length > 1) errors.push(`${path}: duplicate ${key} values ${JSON.stringify(values)}`);
+    if (values.length > 1)
+      errors.push(`${path}: duplicate ${key} values ${JSON.stringify(values)}`);
   }
   if (canonicalUrls.length !== 1 || canonicalUrls[0] !== canonicalUrl) {
     errors.push(
       `${path}: canonical must occur once as "${canonicalUrl}", received ${JSON.stringify(canonicalUrls)}`
     );
+  }
+}
+
+function requireBuiltText(path, requiredText) {
+  if (!existsSync(path)) {
+    errors.push(`Missing built route: ${path}`);
+    return;
+  }
+
+  const html = readFileSync(path, 'utf8');
+  for (const text of requiredText) {
+    if (!html.includes(text)) errors.push(`${path}: missing visible content "${text}"`);
   }
 }
 
@@ -99,6 +112,18 @@ requireMetadata('out/index.html', 'https://degov.ai/', {
   'twitter:description':
     'DeGov.AI helps communities run governance with Square and understand governance with Atlas.'
 });
+requireBuiltText('out/index.html', [
+  'Content provenance',
+  'Canonical owner:',
+  'DeGov official website.',
+  'Editorial review:',
+  '2026-08-05.',
+  'not deploy or build freshness',
+  'https://docs.degov.ai/',
+  'https://square.degov.ai/',
+  'https://atlas.degov.ai/',
+  'https://github.com/ringecosystem/degov'
+]);
 requireMetadata('out/pricing/index.html', 'https://degov.ai/pricing/', {
   ...sharedMetadata,
   title: 'Square Pricing — DeGov.AI',
@@ -109,7 +134,8 @@ requireMetadata('out/pricing/index.html', 'https://degov.ai/pricing/', {
     'Self-host Square for free or choose managed hosting, with the first six months free.',
   'og:url': 'https://degov.ai/pricing/',
   'twitter:title': 'Square Pricing — DeGov.AI',
-  'twitter:description': 'Self-host Square for free or choose managed hosting, with six months free.'
+  'twitter:description':
+    'Self-host Square for free or choose managed hosting, with six months free.'
 });
 
 // Validate the copied build artifact rather than only its source file so a
@@ -122,7 +148,9 @@ if (!existsSync(builtImagePath)) {
     const sourceImage = validateRgbPng('public/images/degov-social-card.png', 1200, 630);
     const builtImage = validateRgbPng(builtImagePath, 1200, 630);
     if (!sourceImage.equals(builtImage)) {
-      errors.push(`${builtImagePath} does not match public/images/degov-social-card.png byte-for-byte`);
+      errors.push(
+        `${builtImagePath} does not match public/images/degov-social-card.png byte-for-byte`
+      );
     }
   } catch (error) {
     errors.push(error.message);
@@ -130,7 +158,9 @@ if (!existsSync(builtImagePath)) {
 }
 
 if (errors.length) {
-  console.error(`Social metadata verification failed:\n${errors.map((error) => `- ${error}`).join('\n')}`);
+  console.error(
+    `Social metadata verification failed:\n${errors.map((error) => `- ${error}`).join('\n')}`
+  );
   process.exit(1);
 }
 

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -433,6 +433,31 @@ export default function HomeClient() {
               Portfolio figures from DeGov product materials. Add a confirmed reporting date before
               launch.
             </p>
+            <div
+              className="content-provenance"
+              data-od-id="homepage-content-provenance"
+              aria-label="Homepage content provenance"
+            >
+              <p className="eyebrow">Content provenance</p>
+              <div className="provenance-grid">
+                <p>
+                  <strong>Canonical owner:</strong> DeGov official website.
+                </p>
+                <p>
+                  <strong>Editorial review:</strong> 2026-08-05.
+                </p>
+                <p>
+                  The review date describes evergreen product-copy review, not deploy or build
+                  freshness.
+                </p>
+                <nav className="provenance-links" aria-label="Primary homepage sources">
+                  <a href="https://docs.degov.ai/">Docs</a>
+                  <a href="https://square.degov.ai/">Square</a>
+                  <a href="https://atlas.degov.ai/">Atlas</a>
+                  <a href="https://github.com/ringecosystem/degov">Source</a>
+                </nav>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/src/app/site.css
+++ b/src/app/site.css
@@ -973,6 +973,45 @@ body.menu-open {
   font-size: var(--text-xs);
 }
 
+.home-site .content-provenance {
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.home-site .provenance-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr minmax(220px, 1.2fr) auto;
+  align-items: start;
+  gap: var(--space-5);
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
+.home-site .provenance-grid strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.home-site .provenance-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.home-site .provenance-links a {
+  color: var(--fg);
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 4px;
+}
+
+.home-site .provenance-links a:hover,
+.home-site .provenance-links a:focus-visible {
+  text-decoration-color: var(--fg);
+}
+
 .home-site .agent-system {
   display: grid;
   grid-template-columns: 0.82fr 1.18fr;
@@ -1877,6 +1916,14 @@ body.menu-open {
   .home-site .ledger-row {
     grid-template-columns: 1fr;
     gap: var(--space-2);
+  }
+
+  .home-site .provenance-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-site .provenance-links {
+    justify-content: flex-start;
   }
 
   .home-site .access-step {


### PR DESCRIPTION
## Summary
- add a visible homepage content provenance block for evergreen product claims
- identify the official site as canonical owner and separate editorial review date from deploy/build freshness
- link primary first-party sources for Docs, Square, Atlas, and source code
- extend homepage/build verifiers so the provenance text is present in rendered HTML

## Verification
- pnpm install --frozen-lockfile
- pnpm run test:design
- pnpm run lint
- pnpm run build
- pnpm exec prettier --check src/app/home-client.tsx src/app/site.css scripts/verify-social-metadata.mjs scripts/verify-design-contract.mjs
- git diff --check
- static raw HTML readback from local `out/` confirmed the visible provenance text and source links

Refs ringecosystem/degov-home#33
Refs ringecosystem/degov#1027
Refs ringecosystem/degov#714
