### PR TITLE
Add official pricing WebPage structured data

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && node scripts/verify-social-metadata.mjs",
+    "build": "next build && node scripts/verify-social-metadata.mjs && node scripts/verify-structured-data.mjs",
     "start": "next start",
     "lint": "eslint src next.config.ts eslint.config.mjs tailwind.config.ts --ext .js,.jsx,.ts,.tsx,.mjs --max-warnings=0",
     "test:design": "node scripts/verify-design-contract.mjs",
+    "test:structured-data": "node scripts/verify-structured-data.mjs",
     "verify": "pnpm lint && pnpm build"
   },
   "dependencies": {

--- a/scripts/verify-design-contract.mjs
+++ b/scripts/verify-design-contract.mjs
@@ -171,8 +171,13 @@ requireIncludes(
 );
 requireIncludes(
   'package.json',
-  '"build": "next build && node scripts/verify-social-metadata.mjs"',
+  '"build": "next build && node scripts/verify-social-metadata.mjs && node scripts/verify-structured-data.mjs"',
   'built social-metadata verification'
+);
+requireIncludes(
+  'package.json',
+  '"test:structured-data": "node scripts/verify-structured-data.mjs"',
+  'structured-data package script'
 );
 requireBinary('public/fonts/GeistMono-Variable.woff2', 50_000);
 requireBinary('public/fonts/UniversalSans-Fallback.woff2', 50_000);

--- a/scripts/verify-structured-data.mjs
+++ b/scripts/verify-structured-data.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+
+const PRICING_URL = 'https://degov.ai/pricing/';
+const PUBLISHER_ID = 'https://degov.ai/#organization';
+const WEBSITE_ID = 'https://degov.ai/#website';
+const errors = [];
+
+function read(path) {
+  if (!existsSync(path)) {
+    errors.push(`Missing built route: ${path}`);
+    return '';
+  }
+
+  return readFileSync(path, 'utf8');
+}
+
+function readAttributes(tag) {
+  const attributes = new Map();
+  for (const [, name, value] of tag.matchAll(/([\w:-]+)="([^"]*)"/g)) {
+    attributes.set(name, value);
+  }
+  return attributes;
+}
+
+function readCanonicalUrls(html) {
+  const canonicalUrls = [];
+  for (const [tag] of html.matchAll(/<link\s+[^>]+>/gi)) {
+    const attributes = readAttributes(tag);
+    if (attributes.get('rel') === 'canonical') canonicalUrls.push(attributes.get('href') ?? '');
+  }
+  return canonicalUrls;
+}
+
+function readJsonLd(html) {
+  const blocks = [];
+  for (const [, body] of html.matchAll(
+    /<script\b[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi
+  )) {
+    try {
+      const parsed = JSON.parse(body);
+      if (Array.isArray(parsed)) blocks.push(...parsed);
+      else blocks.push(parsed);
+    } catch (error) {
+      errors.push(`Invalid JSON-LD block: ${error.message}`);
+    }
+  }
+  return blocks;
+}
+
+function requireEqual(actual, expected, label) {
+  if (actual !== expected) errors.push(`${label} must be ${expected}, received ${actual}`);
+}
+
+function requireIncludes(html, needle, label = needle) {
+  if (!html.includes(needle)) errors.push(`Missing visible content: ${label}`);
+}
+
+const pricingHtml = read('out/pricing/index.html');
+const canonicalUrls = readCanonicalUrls(pricingHtml);
+if (canonicalUrls.length !== 1 || canonicalUrls[0] !== PRICING_URL) {
+  errors.push(
+    `Pricing canonical must occur once as ${PRICING_URL}, received ${JSON.stringify(canonicalUrls)}`
+  );
+}
+
+requireIncludes(pricingHtml, 'Start managed. Stay in control.', 'pricing visible H1');
+requireIncludes(
+  pricingHtml,
+  'Self-hosted and managed deployments run the same open-source DeGov code.',
+  'pricing visible content description'
+);
+
+const jsonLd = readJsonLd(pricingHtml);
+const pricingWebPage = jsonLd.find((item) => item?.['@type'] === 'WebPage');
+if (!pricingWebPage) {
+  errors.push('Pricing page must emit generic WebPage JSON-LD');
+} else {
+  requireEqual(pricingWebPage['@id'], `${PRICING_URL}#webpage`, 'WebPage @id');
+  requireEqual(pricingWebPage.url, PRICING_URL, 'WebPage url');
+  requireEqual(pricingWebPage.name, 'Square Pricing — DeGov.AI', 'WebPage name');
+  requireEqual(pricingWebPage.headline, 'Start managed. Stay in control.', 'WebPage headline');
+  requireEqual(pricingWebPage.publisher?.['@id'], PUBLISHER_ID, 'WebPage publisher @id');
+  requireEqual(pricingWebPage.isPartOf?.['@id'], WEBSITE_ID, 'WebPage isPartOf @id');
+  requireEqual(pricingWebPage.mainEntityOfPage, PRICING_URL, 'WebPage mainEntityOfPage');
+  if (!pricingHtml.includes(pricingWebPage.headline)) {
+    errors.push('WebPage headline must match visible pricing content');
+  }
+}
+
+const forbiddenTypes = new Set(['Product', 'Offer', 'AggregateRating', 'Review']);
+for (const block of jsonLd) {
+  const types = Array.isArray(block?.['@type']) ? block['@type'] : [block?.['@type']];
+  for (const type of types) {
+    if (forbiddenTypes.has(type)) errors.push(`Forbidden richer schema type emitted: ${type}`);
+  }
+}
+
+const organization = jsonLd.find((item) => item?.['@type'] === 'Organization');
+if (organization) {
+  requireEqual(organization['@id'], PUBLISHER_ID, 'Organization @id');
+}
+
+const website = jsonLd.find((item) => item?.['@type'] === 'WebSite');
+if (website) {
+  requireEqual(website['@id'], WEBSITE_ID, 'WebSite @id');
+  requireEqual(website.publisher?.['@id'], PUBLISHER_ID, 'WebSite publisher @id');
+}
+
+if (errors.length) {
+  console.error(
+    `Structured-data verification failed:\n${errors.map((error) => `- ${error}`).join('\n')}`
+  );
+  process.exit(1);
+}
+
+console.log('Structured-data verification passed for /pricing/.');

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
-import { SITE_URL, SOCIAL_IMAGE_ALT, SOCIAL_IMAGE_URL } from '@/lib/seo';
+import { PRICING_WEBPAGE, SITE_URL, SOCIAL_IMAGE_ALT, SOCIAL_IMAGE_URL } from '@/lib/seo';
 import PricingClient from './pricing-client';
+
+const PRICING_WEBPAGE_STRUCTURED_DATA = JSON.stringify(PRICING_WEBPAGE);
 
 export const metadata: Metadata = {
   title: {
@@ -40,5 +42,14 @@ export const metadata: Metadata = {
 };
 
 export default function PricingPage() {
-  return <PricingClient />;
+  return (
+    <>
+      <PricingClient />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: PRICING_WEBPAGE_STRUCTURED_DATA }}
+      />
+    </>
+  );
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,7 @@
 export const SITE_URL = 'https://degov.ai';
+export const PUBLISHER_ID = `${SITE_URL}/#organization`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+export const PRICING_URL = `${SITE_URL}/pricing/`;
 
 // A distinct asset URL helps social platforms invalidate the cached square
 // logo that was previously advertised as a large preview card.
@@ -7,6 +10,7 @@ export const SOCIAL_IMAGE_ALT = 'DeGov.AI — Better governance for better commu
 
 export const SEO_ORGANIZATION = {
   '@context': 'https://schema.org',
+  '@id': PUBLISHER_ID,
   '@type': 'Organization',
   name: 'DeGov.AI',
   url: SITE_URL,
@@ -21,9 +25,35 @@ export const SEO_ORGANIZATION = {
 
 export const SEO_WEBSITE = {
   '@context': 'https://schema.org',
+  '@id': WEBSITE_ID,
   '@type': 'WebSite',
   name: 'DeGov.AI',
   url: SITE_URL,
+  publisher: {
+    '@id': PUBLISHER_ID
+  },
   description:
     'Better governance for better communities. Run governance with Square and understand it with Atlas.'
+};
+
+export const PRICING_WEBPAGE = {
+  '@context': 'https://schema.org',
+  '@id': `${PRICING_URL}#webpage`,
+  '@type': 'WebPage',
+  url: PRICING_URL,
+  name: 'Square Pricing — DeGov.AI',
+  headline: 'Start managed. Stay in control.',
+  description:
+    'DeGov.AI Square pricing: self-host for free or choose managed hosting, with the first six months free.',
+  isPartOf: {
+    '@id': WEBSITE_ID
+  },
+  publisher: {
+    '@id': PUBLISHER_ID
+  },
+  mainEntityOfPage: PRICING_URL,
+  about: {
+    '@type': 'Thing',
+    name: 'DeGov Square managed hosting'
+  }
 };


### PR DESCRIPTION
## Summary

- add stable DeGov publisher and website `@id` values
- emit generic `WebPage` JSON-LD for the official `/pricing/` content page
- add a build-output structured-data verifier for visible-content, canonical, publisher identity, and forbidden richer schema checks

## Tracking

- Implements the repository code slice for ringecosystem/degov-home#35
- Supports ringecosystem/degov#1028 and ringecosystem/degov#714

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm build`
- `pnpm test:structured-data`
- `pnpm test:design`
- `git diff --check`
