### PR TITLE
Add official site product navigation analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint src next.config.ts eslint.config.mjs tailwind.config.ts --ext .js,.jsx,.ts,.tsx,.mjs --max-warnings=0",
     "test:design": "node scripts/verify-design-contract.mjs",
+    "test:product-navigation-analytics": "node --experimental-strip-types scripts/verify-product-navigation-analytics.mjs",
     "test:structured-data": "node scripts/verify-structured-data.mjs",
     "verify": "pnpm lint && pnpm build"
   },

--- a/scripts/verify-product-navigation-analytics.mjs
+++ b/scripts/verify-product-navigation-analytics.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildProductNavigationEventParams,
+  getChannelGroupFromReferrer,
+  getProductNavigationTarget,
+  PRODUCT_NAVIGATION_EVENT_NAME
+} from '../src/lib/analytics.ts';
+
+const root = join(fileURLToPath(new URL('..', import.meta.url)));
+const read = (path) => readFileSync(join(root, path), 'utf8');
+
+assert.equal(PRODUCT_NAVIGATION_EVENT_NAME, 'degov_product_navigation');
+
+assert.deepEqual(getProductNavigationTarget('/pricing'), {
+  target_surface: 'pricing',
+  target_path_class: 'pricing'
+});
+assert.deepEqual(getProductNavigationTarget('https://docs.degov.ai/integration/deploy/'), {
+  target_surface: 'docs',
+  target_path_class: 'integration'
+});
+assert.deepEqual(getProductNavigationTarget('https://square.degov.ai/dao/lisk'), {
+  target_surface: 'square',
+  target_path_class: 'dao-detail'
+});
+assert.deepEqual(getProductNavigationTarget('https://atlas.degov.ai/'), {
+  target_surface: 'atlas',
+  target_path_class: 'root'
+});
+assert.equal(getProductNavigationTarget('mailto:contact@degov.ai'), null);
+assert.equal(getProductNavigationTarget('https://github.com/ringecosystem/degov'), null);
+
+assert.deepEqual(
+  buildProductNavigationEventParams({
+    targetUrl: 'https://square.degov.ai/',
+    referrer: 'https://www.google.com/search?q=degov',
+    currentHost: 'degov.ai',
+    locale: 'en'
+  }),
+  {
+    source_surface: 'home',
+    target_surface: 'square',
+    target_path_class: 'root',
+    channel_group: 'organic-search',
+    locale: 'en'
+  }
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://www.degov.ai/pricing', 'degov.ai'),
+  'direct-unknown'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://chatgpt.com/share/example', 'degov.ai'),
+  'ai-search-assistant-referral'
+);
+assert.equal(getChannelGroupFromReferrer('https://x.com/ai_degov', 'degov.ai'), 'social-organic');
+assert.equal(
+  getChannelGroupFromReferrer('https://docs.degov.ai/faqs', 'degov.ai'),
+  'documentation-referral'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://sex.com/post', 'degov.ai'),
+  'other-external-referral'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://evilbing.com/post', 'degov.ai'),
+  'other-external-referral'
+);
+
+const analyticsSource = read('src/lib/analytics.ts');
+const componentSource = read('src/components/ProductNavigationAnalytics.tsx');
+const layoutSource = read('src/app/layout.tsx');
+const combinedSource = `${analyticsSource}\n${componentSource}\n${layoutSource}`;
+
+assert.deepEqual(
+  Object.keys(
+    buildProductNavigationEventParams({
+      targetUrl: '/pricing',
+      referrer: '',
+      currentHost: 'degov.ai',
+      locale: 'en'
+    })
+  ).sort(),
+  ['channel_group', 'locale', 'source_surface', 'target_path_class', 'target_surface']
+);
+
+for (const field of [
+  'wallet_address',
+  'auth_state',
+  'full_query_string',
+  'window.location.search',
+  'window.location.href'
+]) {
+  assert.ok(!combinedSource.includes(field), `analytics source must not include ${field}`);
+}
+
+assert.ok(
+  layoutSource.includes('<ProductNavigationAnalytics />'),
+  'root layout must mount product navigation analytics once'
+);
+assert.ok(
+  componentSource.includes(
+    '`${PRODUCT_NAVIGATION_EVENT_NAME}:${params.target_surface}:${params.target_path_class}`'
+  ),
+  'dedupe key must use session plus target surface plus target path class'
+);
+
+console.log('Product navigation analytics verification passed.');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   SOCIAL_IMAGE_ALT,
   SOCIAL_IMAGE_URL
 } from '@/lib/seo';
+import { ProductNavigationAnalytics } from '@/components/ProductNavigationAnalytics';
 
 const STRUCTURED_DATA = JSON.stringify([SEO_ORGANIZATION, SEO_WEBSITE]);
 
@@ -97,6 +98,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <ProductNavigationAnalytics />
         {children}
         <script
           type="application/ld+json"

--- a/src/components/ProductNavigationAnalytics.tsx
+++ b/src/components/ProductNavigationAnalytics.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import {
+  buildProductNavigationEventParams,
+  PRODUCT_NAVIGATION_EVENT_NAME,
+  sendProductNavigationEvent
+} from '@/lib/analytics';
+
+export function ProductNavigationAnalytics() {
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const link = target.closest('a[href]');
+      const href = link?.getAttribute('href');
+      const params = buildProductNavigationEventParams({
+        targetUrl: href,
+        referrer: document.referrer,
+        currentHost: window.location.hostname,
+        locale: document.documentElement.lang
+      });
+
+      if (!params) return;
+
+      const dedupeKey = `${PRODUCT_NAVIGATION_EVENT_NAME}:${params.target_surface}:${params.target_path_class}`;
+
+      try {
+        if (window.sessionStorage.getItem(dedupeKey)) return;
+        if (sendProductNavigationEvent(params)) {
+          window.sessionStorage.setItem(dedupeKey, '1');
+        }
+      } catch {
+        sendProductNavigationEvent(params);
+      }
+    };
+
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
+  }, []);
+
+  return null;
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,204 @@
+'use client';
+
+export const PRODUCT_NAVIGATION_EVENT_NAME = 'degov_product_navigation';
+
+export type ChannelGroup =
+  | 'organic-search'
+  | 'social-organic'
+  | 'documentation-referral'
+  | 'cross-product-degov-referral'
+  | 'ai-search-assistant-referral'
+  | 'other-external-referral'
+  | 'direct-unknown';
+
+export type TargetSurface = 'docs' | 'square' | 'atlas' | 'pricing';
+export type TargetPathClass =
+  | 'root'
+  | 'pricing'
+  | 'integration'
+  | 'dao-directory'
+  | 'dao-detail'
+  | 'other';
+
+export type ProductNavigationEventParams = {
+  source_surface: 'home';
+  target_surface: TargetSurface;
+  target_path_class: TargetPathClass;
+  channel_group: ChannelGroup;
+  locale: string;
+};
+
+declare global {
+  interface Window {
+    gtag?: (command: 'event', eventName: string, params: ProductNavigationEventParams) => void;
+  }
+}
+
+const SEARCH_HOST_SUBSTRINGS = ['google.', 'yahoo.'];
+const SEARCH_HOST_DOMAINS = ['bing.com', 'duckduckgo.com', 'baidu.com', 'yandex.com'];
+const SOCIAL_HOSTS = [
+  'x.com',
+  'twitter.com',
+  'linkedin.com',
+  'facebook.com',
+  'discord.com',
+  'telegram.org',
+  't.me'
+];
+const AI_REFERRER_HOSTS = [
+  'chatgpt.com',
+  'perplexity.ai',
+  'copilot.microsoft.com',
+  'gemini.google.com'
+];
+
+function normalizeHost(hostname: string | null | undefined): string {
+  return String(hostname ?? '')
+    .toLowerCase()
+    .replace(/^www\./, '');
+}
+
+function normalizePathname(pathname: string | null | undefined): string {
+  const path = String(pathname ?? '/').toLowerCase();
+  return path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path;
+}
+
+function hostMatchesDomain(hostname: string, candidate: string): boolean {
+  return hostname === candidate || hostname.endsWith(`.${candidate}`);
+}
+
+function hostMatchesDomains(hostname: string, candidates: string[]): boolean {
+  return candidates.some((candidate) => hostMatchesDomain(hostname, candidate));
+}
+
+export function getChannelGroupFromReferrer(
+  referrer: string | null | undefined,
+  currentHost: string | null | undefined
+): ChannelGroup {
+  if (!referrer) return 'direct-unknown';
+
+  let referrerUrl: URL;
+  try {
+    referrerUrl = new URL(referrer);
+  } catch {
+    return 'direct-unknown';
+  }
+
+  const referrerHost = normalizeHost(referrerUrl.hostname);
+  const current = normalizeHost(currentHost);
+
+  if (current && referrerHost === current) {
+    return 'direct-unknown';
+  }
+
+  if (hostMatchesDomains(referrerHost, AI_REFERRER_HOSTS)) {
+    return 'ai-search-assistant-referral';
+  }
+
+  if (
+    SEARCH_HOST_SUBSTRINGS.some((candidate) => referrerHost.includes(candidate)) ||
+    hostMatchesDomains(referrerHost, SEARCH_HOST_DOMAINS)
+  ) {
+    return 'organic-search';
+  }
+
+  if (hostMatchesDomains(referrerHost, SOCIAL_HOSTS)) {
+    return 'social-organic';
+  }
+
+  if (referrerHost === 'docs.degov.ai') {
+    return 'documentation-referral';
+  }
+
+  if (referrerHost.endsWith('.degov.ai') || referrerHost === 'degov.ai') {
+    return 'cross-product-degov-referral';
+  }
+
+  return 'other-external-referral';
+}
+
+export function getProductNavigationTarget(targetUrl: string | null | undefined): {
+  target_surface: TargetSurface;
+  target_path_class: TargetPathClass;
+} | null {
+  if (!targetUrl) return null;
+
+  let url: URL;
+  try {
+    url = new URL(targetUrl, 'https://degov.ai/');
+  } catch {
+    return null;
+  }
+
+  const host = normalizeHost(url.hostname);
+  const path = normalizePathname(url.pathname);
+
+  if (host === 'docs.degov.ai') {
+    return {
+      target_surface: 'docs',
+      target_path_class: path.startsWith('/integration')
+        ? 'integration'
+        : path === '/'
+          ? 'root'
+          : 'other'
+    };
+  }
+
+  if (host === 'square.degov.ai') {
+    return {
+      target_surface: 'square',
+      target_path_class: path.startsWith('/dao/')
+        ? 'dao-detail'
+        : path === '/'
+          ? 'root'
+          : 'dao-directory'
+    };
+  }
+
+  if (host === 'atlas.degov.ai') {
+    return {
+      target_surface: 'atlas',
+      target_path_class: path === '/' ? 'root' : 'other'
+    };
+  }
+
+  if (host === 'degov.ai' && path === '/pricing') {
+    return {
+      target_surface: 'pricing',
+      target_path_class: 'pricing'
+    };
+  }
+
+  return null;
+}
+
+export function buildProductNavigationEventParams({
+  targetUrl,
+  referrer,
+  currentHost,
+  locale
+}: {
+  targetUrl: string | null | undefined;
+  referrer: string | null | undefined;
+  currentHost: string | null | undefined;
+  locale: string | null | undefined;
+}): ProductNavigationEventParams | null {
+  const target = getProductNavigationTarget(targetUrl);
+  if (!target) return null;
+
+  return {
+    source_surface: 'home',
+    ...target,
+    channel_group: getChannelGroupFromReferrer(referrer, currentHost),
+    locale: String(locale || 'en').slice(0, 16)
+  };
+}
+
+export function sendProductNavigationEvent(params: ProductNavigationEventParams): boolean {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return false;
+  }
+
+  window.gtag('event', PRODUCT_NAVIGATION_EVENT_NAME, params);
+  return true;
+}


### PR DESCRIPTION
## Summary

- add privacy-safe `degov_product_navigation` tracking for official-site clicks to Docs, Square, Atlas, and Pricing
- classify only observable referrers into the approved channel groups
- send only the approved source surface, target surface, target path class, channel group, and locale payload
- add a product-navigation analytics verification script

## Verification

- `pnpm run test:product-navigation-analytics`
- `pnpm run lint`
- `pnpm exec prettier --check src/lib/analytics.ts src/components/ProductNavigationAnalytics.tsx src/app/layout.tsx scripts/verify-product-navigation-analytics.mjs package.json`
- `pnpm run build`

Refs ringecosystem/degov#1031
Refs ringecosystem/degov#714
Refs #37