### PR TITLE
Enable GA4 for DeGov Home production

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,7 +25,7 @@ jobs:
           project_name: degov-home
           dist_path: out
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm build
+          script_build: pnpm test:product-navigation-analytics && pnpm build
           enable_notify_comment: true
           enable_notify_slack: false
           slack_channel: public-degov

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,7 +25,7 @@ jobs:
           project_name: degov-home
           dist_path: out
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm test:product-navigation-analytics && pnpm build
+          script_build: pnpm build && pnpm test:product-navigation-analytics -- --expect-disabled
           enable_notify_comment: true
           enable_notify_slack: false
           slack_channel: public-degov

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -28,7 +28,7 @@ jobs:
           dist_path: out
           prod_mode: true
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm test:product-navigation-analytics && NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build
+          script_build: NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build && pnpm test:product-navigation-analytics -- --expect-enabled
           enable_notify_slack: true
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -28,7 +28,7 @@ jobs:
           dist_path: out
           prod_mode: true
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm build
+          script_build: NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build
           enable_notify_slack: true
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -28,7 +28,7 @@ jobs:
           dist_path: out
           prod_mode: true
           script_install: pnpm install --frozen-lockfile
-          script_build: NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build
+          script_build: pnpm test:product-navigation-analytics && NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build
           enable_notify_slack: true
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -26,7 +26,7 @@ jobs:
           project_name: degov-home
           dist_path: out
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm test:product-navigation-analytics && pnpm build
+          script_build: pnpm build && pnpm test:product-navigation-analytics -- --expect-disabled
           enable_notify_slack: false
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -26,7 +26,7 @@ jobs:
           project_name: degov-home
           dist_path: out
           script_install: pnpm install --frozen-lockfile
-          script_build: pnpm build
+          script_build: pnpm test:product-navigation-analytics && pnpm build
           enable_notify_slack: false
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}

--- a/scripts/verify-product-navigation-analytics.mjs
+++ b/scripts/verify-product-navigation-analytics.mjs
@@ -120,6 +120,21 @@ assert.ok(
   'GA4 initialization must be gated by a build-time public environment flag'
 );
 assert.ok(
+  layoutSource.indexOf("gtag('consent', 'default'") < layoutSource.indexOf("gtag('config'"),
+  'GA4 consent defaults must be denied before configuration'
+);
+for (const storage of [
+  'analytics_storage',
+  'ad_storage',
+  'ad_user_data',
+  'ad_personalization'
+]) {
+  assert.ok(
+    layoutSource.includes(`${storage}: 'denied'`),
+    `${storage} must default to denied`
+  );
+}
+assert.ok(
   productionWorkflow.includes('NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build'),
   'production tag workflow must enable GA4 at build time'
 );

--- a/scripts/verify-product-navigation-analytics.mjs
+++ b/scripts/verify-product-navigation-analytics.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,6 +12,16 @@ import {
 
 const root = join(fileURLToPath(new URL('..', import.meta.url)));
 const read = (path) => readFileSync(join(root, path), 'utf8');
+const artifactExpectation = process.argv.find((arg) => arg.startsWith('--expect-'));
+
+function readGeneratedFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = join(directory, entry.name);
+      return entry.isDirectory() ? readGeneratedFiles(path) : [readFileSync(path, 'utf8')];
+    })
+    .join('\n');
+}
 
 assert.equal(PRODUCT_NAVIGATION_EVENT_NAME, 'degov_product_navigation');
 
@@ -146,5 +156,26 @@ assert.ok(
   !previewWorkflow.includes('NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED'),
   'PR preview workflow must not enable production GA4'
 );
+
+if (artifactExpectation) {
+  assert.ok(
+    ['--expect-enabled', '--expect-disabled'].includes(artifactExpectation),
+    'artifact expectation must be --expect-enabled or --expect-disabled'
+  );
+  const artifact = readGeneratedFiles(join(root, 'out'));
+  if (artifactExpectation === '--expect-enabled') {
+    assert.ok(artifact.includes('G-QRLBRTT5X1'), 'production artifact must contain GA4 ID');
+    assert.ok(
+      artifact.includes('analytics_storage') && artifact.includes('denied'),
+      'production artifact must preserve denied consent defaults'
+    );
+  } else {
+    assert.ok(!artifact.includes('G-QRLBRTT5X1'), 'non-production artifact must exclude GA4 ID');
+    assert.ok(
+      !artifact.includes('googletagmanager.com/gtag/js'),
+      'non-production artifact must exclude the Google tag loader'
+    );
+  }
+}
 
 console.log('Product navigation analytics verification passed.');

--- a/scripts/verify-product-navigation-analytics.mjs
+++ b/scripts/verify-product-navigation-analytics.mjs
@@ -74,6 +74,9 @@ assert.equal(
 const analyticsSource = read('src/lib/analytics.ts');
 const componentSource = read('src/components/ProductNavigationAnalytics.tsx');
 const layoutSource = read('src/app/layout.tsx');
+const productionWorkflow = read('.github/workflows/deploy-prd.yml');
+const stagingWorkflow = read('.github/workflows/deploy-stg.yml');
+const previewWorkflow = read('.github/workflows/deploy-dev.yml');
 const combinedSource = `${analyticsSource}\n${componentSource}\n${layoutSource}`;
 
 assert.deepEqual(
@@ -107,6 +110,26 @@ assert.ok(
     '`${PRODUCT_NAVIGATION_EVENT_NAME}:${params.target_surface}:${params.target_path_class}`'
   ),
   'dedupe key must use session plus target surface plus target path class'
+);
+assert.ok(
+  layoutSource.includes("const GA4_MEASUREMENT_ID = 'G-QRLBRTT5X1'"),
+  'GA4 must use the public production measurement ID'
+);
+assert.ok(
+  layoutSource.includes("process.env.NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED === 'true'"),
+  'GA4 initialization must be gated by a build-time public environment flag'
+);
+assert.ok(
+  productionWorkflow.includes('NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED=true pnpm build'),
+  'production tag workflow must enable GA4 at build time'
+);
+assert.ok(
+  !stagingWorkflow.includes('NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED'),
+  'staging workflow must not enable production GA4'
+);
+assert.ok(
+  !previewWorkflow.includes('NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED'),
+  'PR preview workflow must not enable production GA4'
 );
 
 console.log('Product navigation analytics verification passed.');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,6 +111,12 @@ export default function RootLayout({
               {`
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
+                gtag('consent', 'default', {
+                  analytics_storage: 'denied',
+                  ad_storage: 'denied',
+                  ad_user_data: 'denied',
+                  ad_personalization: 'denied'
+                });
                 gtag('js', new Date());
                 gtag('config', '${GA4_MEASUREMENT_ID}');
               `}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
+import Script from 'next/script';
 
 import {
   SEO_ORGANIZATION,
@@ -11,6 +12,8 @@ import {
 import { ProductNavigationAnalytics } from '@/components/ProductNavigationAnalytics';
 
 const STRUCTURED_DATA = JSON.stringify([SEO_ORGANIZATION, SEO_WEBSITE]);
+const GA4_MEASUREMENT_ID = 'G-QRLBRTT5X1';
+const IS_GA4_ENABLED = process.env.NEXT_PUBLIC_DEGOV_HOME_GA4_ENABLED === 'true';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -98,6 +101,22 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        {IS_GA4_ENABLED ? (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA4_MEASUREMENT_ID}');
+              `}
+            </Script>
+          </>
+        ) : null}
         <ProductNavigationAnalytics />
         {children}
         <script


### PR DESCRIPTION
## Summary
- initialize the DeGov Home GA4 property only in production tag builds
- preserve the existing privacy-safe product navigation event
- keep staging and PR preview artifacts free of the production Measurement ID

## Validation
- pnpm test:product-navigation-analytics
- pnpm lint
- pnpm build with analytics disabled
- production-gated pnpm build with analytics enabled

Closes #39